### PR TITLE
fix: add website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 This library compares two arrays or objects and returns a full diff of their differences.
 
+ℹ️ The documentation is also available on our [website](https://superdiff.gitbook.io/donedeal0-superdiff)!
+
 <hr/>
 
 ## WHY YOU SHOULD USE THIS LIBRARY

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@donedeal0/superdiff",
-  "version": "3.2.0",
+  "version": "3.1.2",
   "type": "module",
   "description": "SuperDiff compares two arrays or objects and returns a full diff of their differences",
   "main": "dist/index.js",


### PR DESCRIPTION
Add the link to the documentation website: https://superdiff.gitbook.io/donedeal0-superdiff

<img width="1502" alt="Capture d’écran 2024-11-03 à 21 36 48" src="https://github.com/user-attachments/assets/8501f365-de8a-44a3-bc58-5a6dd7f62d28">
